### PR TITLE
Add command to start server and app together 

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "onboardio",
   "version": "0.1.0",
   "private": true,
+  "workspaces": [
+    "server"
+  ],
   "dependencies": {
     "@chakra-ui/core": "^0.8.0",
     "@emotion/core": "^10.0.35",
@@ -21,6 +24,8 @@
   },
   "scripts": {
     "start": "react-scripts start",
+    "start:server": "yarn workspace server dev",
+    "start:app": "yarn start:server & yarn start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/server/api/middlewares/requestLogger.ts
+++ b/server/api/middlewares/requestLogger.ts
@@ -8,7 +8,7 @@ export const RequestLogger = (req, res, next) => {
     const elapsedHrTime = process.hrtime(startHrTime);
     const elapsedTimeInMs = elapsedHrTime[0] * 1000 + elapsedHrTime[1] / 1e6;
     Logger.info(
-      chalk.cyanBright.bold(req.baseUrl + req.path),
+      chalk.cyanBright.bold(req.path),
       `${chalk.whiteBright.bold(res.statusCode)} (${chalk.whiteBright.bold(
         elapsedTimeInMs
       )} ms)`

--- a/server/package.json
+++ b/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "onboardio-api",
+  "name": "server",
   "version": "1.0.0",
   "description": "REST API, written in TypeScript, serving from MongoDB",
   "main": "server.js",


### PR DESCRIPTION
- [x]  Use yarn workspaces for server
- [x]  Define a command `start:app` in package.json which starts react frontend and server together.

Use `yarn start:app` to quick start the app